### PR TITLE
Netsarlacc joeddy

### DIFF
--- a/logger.go
+++ b/logger.go
@@ -1,30 +1,30 @@
 package main
 
 import (
-	"gopkg.in/natefinch/lumberjack.v2"
-	"log"
-	"log/syslog"
-	"fmt"
+        "gopkg.in/natefinch/lumberjack.v2"
+        "log"
+        "log/syslog"
+        "fmt"
 )
 
 func AppLogger(err error) {
-	logwriter, e := syslog.New(syslog.LOG_CRIT, "netsarlacc")
-	if e == nil {
-		log.SetOutput(logwriter)
-	}
-	log.Print(err)
+        logwriter, e := syslog.New(syslog.LOG_CRIT, "netsarlacc")
+        if e == nil {
+                log.SetOutput(logwriter)
+        }
+        log.Print(err)
 }
 
 func ConnLogger(v interface{}) {
-	log.SetOutput(&lumberjack.Logger{
-		Filename: "netsarlacc.log",
-		MaxSize:  1, // megabytes
-	})
-	log.Println(v)
+        log.SetOutput(&lumberjack.Logger{
+                Filename: "netsarlacc.log",
+                MaxSize:  1, // megabytes
+        })
+        log.Println(v)
 }
 
-func writeLogger(logChan chan string) {
-	s := <-logChan
-	fmt.Println(s)
+func writeLogger(Logchan chan string) {
+        for v := range Logchan {
+        fmt.Println(v)
+        }
 }
-	

--- a/logger.go
+++ b/logger.go
@@ -18,14 +18,6 @@ func AppLogger(err error) {
         log.Print(err)
 }
 
-func ConnLogger(v interface{}) {
-        log.SetOutput(&lumberjack.Logger{
-                Filename: "netsarlacc.log",
-                MaxSize:  1, // megabytes
-        })
-        log.Println(v)
-}
-
 func writeLogger(Logchan chan string) {
         //variables
         var logFile *os.File

--- a/logger.go
+++ b/logger.go
@@ -4,6 +4,7 @@ import (
 	"gopkg.in/natefinch/lumberjack.v2"
 	"log"
 	"log/syslog"
+	"fmt"
 )
 
 func AppLogger(err error) {
@@ -21,3 +22,9 @@ func ConnLogger(v interface{}) {
 	})
 	log.Println(v)
 }
+
+func writeLogger(logChan chan string) {
+	s := <-logChan
+	fmt.Println(s)
+}
+	

--- a/logger.go
+++ b/logger.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-        "gopkg.in/natefinch/lumberjack.v2"
         "log"
         "log/syslog"
         "fmt"

--- a/logger.go
+++ b/logger.go
@@ -30,23 +30,25 @@ func writeLogger(Logchan chan string) {
         //variables
         var logFile *os.File
         var writeFile bool = true
-        
-        //get current datetime and creates filename based on current time
-        now := time.Now()
-        filename := ("sinkhole-" + now.Format("2006-01-02-15-04-05") + ".log")
-        
-        //create inital file
-        logFile, err = os.OpenFile(filename, os.O_CREATE|os.O_RDWR, 0666)
-        if err != nil {
-                log.Fatal(err)
-        }
-        
+	var err error
+
         //ticker and file rotation goroutine
         ticker := time.NewTicker(time.Minute * 10)
         go func() {
-                for t := range ticker.C {
+        	//get current datetime and creates filename based on current time
+        	now := time.Now()
+        	filename := ("sinkhole-" + now.Format("2006-01-02-15-04-05") + ".log")
+
+        	//create inital file
+        	logFile, err = os.OpenFile(filename, os.O_CREATE|os.O_RDWR, 0666)
+        	if err != nil {
+                	log.Fatal(err)
+       		}
+                for range ticker.C {
                         writeFile = false
-                        logfile.Close()
+                        logFile.Close()
+			//get current datetime and creates filename based on current time
+        		now := time.Now()
                         filename := ("sinkhole-" + now.Format("2006-01-02-15-04-05") + ".log")
                         logFile, err = os.OpenFile(filename, os.O_CREATE|os.O_RDWR, 0666)
                         if err != nil {
@@ -54,13 +56,13 @@ func writeLogger(Logchan chan string) {
                         }
                         writeFile = true
                 }
-        }
-                        
-        
-        defer logfile.Close()
+        }()
+
+
+        defer logFile.Close()
 
         for l := range Logchan {
-                if writeFile = true{
+                if writeFile == true{
                         n, err := io.WriteString(logFile, l + "\n")
                         if err != nil {
                                 fmt.Println(n, err)

--- a/logger.go
+++ b/logger.go
@@ -5,6 +5,8 @@ import (
         "log"
         "log/syslog"
         "fmt"
+        "os"
+        "io"
 )
 
 func AppLogger(err error) {
@@ -23,8 +25,32 @@ func ConnLogger(v interface{}) {
         log.Println(v)
 }
 
+func RotateLogFile(file *os.File) {
+                
+}
+
 func writeLogger(Logchan chan string) {
-        for v := range Logchan {
-        fmt.Println(v)
+        var logFile *os.File
+
+        //check to see if log file exsits already
+        if _, err := os.Stat("/path/to/whatever"); os.IsNotExist(err) {
+                // if file does not exist then create the file
+                logFile, err = os.OpenFile("test.log", os.O_CREATE|os.O_RDWR, 0666)
+                if err != nil {
+                        log.Fatal(err)
+                }
+        } else {
+                // if the file does exist truncate it
+                logFile, err = os.OpenFile("test.log", os.O_TRUNC|os.O_RDWR, 0666)
+                if err != nil {
+                        log.Fatal(err)
+                }
+        }
+
+        for l := range Logchan {
+                n, err := io.WriteString(logFile, l + "\n")
+                if err != nil {
+                        fmt.Println(n, err)
+                }
         }
 }

--- a/logger.go
+++ b/logger.go
@@ -7,6 +7,7 @@ import (
         "fmt"
         "os"
         "io"
+        "time"
 )
 
 func AppLogger(err error) {
@@ -25,27 +26,20 @@ func ConnLogger(v interface{}) {
         log.Println(v)
 }
 
-func RotateLogFile(file *os.File) {
-                
-}
-
 func writeLogger(Logchan chan string) {
         var logFile *os.File
-
-        //check to see if log file exsits already
-        if _, err := os.Stat("/path/to/whatever"); os.IsNotExist(err) {
-                // if file does not exist then create the file
-                logFile, err = os.OpenFile("test.log", os.O_CREATE|os.O_RDWR, 0666)
-                if err != nil {
-                        log.Fatal(err)
-                }
-        } else {
-                // if the file does exist truncate it
-                logFile, err = os.OpenFile("test.log", os.O_TRUNC|os.O_RDWR, 0666)
-                if err != nil {
-                        log.Fatal(err)
-                }
+        
+        //get current datetime and creates filename based on current time
+        now := time.Now()
+        filename := ("sinkhole-" + now.Format("2006-01-02-15-04-05") + ".log")
+        
+        //create file
+        logFile, err = os.OpenFile(filename, os.O_CREATE|os.O_RDWR, 0666)
+        if err != nil {
+                log.Fatal(err)
         }
+        
+        defer logfile.Close()
 
         for l := range Logchan {
                 n, err := io.WriteString(logFile, l + "\n")

--- a/logger.go
+++ b/logger.go
@@ -27,24 +27,44 @@ func ConnLogger(v interface{}) {
 }
 
 func writeLogger(Logchan chan string) {
+        //variables
         var logFile *os.File
+        var writeFile bool = true
         
         //get current datetime and creates filename based on current time
         now := time.Now()
         filename := ("sinkhole-" + now.Format("2006-01-02-15-04-05") + ".log")
         
-        //create file
+        //create inital file
         logFile, err = os.OpenFile(filename, os.O_CREATE|os.O_RDWR, 0666)
         if err != nil {
                 log.Fatal(err)
         }
         
+        //ticker and file rotation goroutine
+        ticker := time.NewTicker(time.Minute * 10)
+        go func() {
+                for t := range ticker.C {
+                        writeFile = false
+                        logfile.Close()
+                        filename := ("sinkhole-" + now.Format("2006-01-02-15-04-05") + ".log")
+                        logFile, err = os.OpenFile(filename, os.O_CREATE|os.O_RDWR, 0666)
+                        if err != nil {
+                                log.Fatal(err)
+                        }
+                        writeFile = true
+                }
+        }
+                        
+        
         defer logfile.Close()
 
         for l := range Logchan {
-                n, err := io.WriteString(logFile, l + "\n")
-                if err != nil {
-                        fmt.Println(n, err)
+                if writeFile = true{
+                        n, err := io.WriteString(logFile, l + "\n")
+                        if err != nil {
+                                fmt.Println(n, err)
+                        }
                 }
         }
 }

--- a/netsarlacc.go
+++ b/netsarlacc.go
@@ -90,6 +90,6 @@ func main() {
 	StartDispatcher(*NWorkers)
 	
 	httpListen()
-	go httpsListen
+	go httpsListen()
 
 }

--- a/netsarlacc.go
+++ b/netsarlacc.go
@@ -63,3 +63,4 @@ func main() {
 	}
 
 }
+test

--- a/netsarlacc.go
+++ b/netsarlacc.go
@@ -42,6 +42,7 @@ func main() {
 	StartDispatcher(*NWorkers)
 	//starts the log channel
 	logChan := make(chan string)
+	go writeLogger(logChan)
 	//listen for incoming connections
 	listen, err := net.Listen(CONN_TYPE, CONN_HOST+":"+CONN_PORT)
 	if err != nil {

--- a/netsarlacc.go
+++ b/netsarlacc.go
@@ -40,6 +40,8 @@ func main() {
 	flag.Parse()
 	//starts the dispatcher
 	StartDispatcher(*NWorkers)
+	//starts the log channel
+	logChan := make(chan struct)
 	//listen for incoming connections
 	listen, err := net.Listen(CONN_TYPE, CONN_HOST+":"+CONN_PORT)
 	if err != nil {

--- a/netsarlacc.go
+++ b/netsarlacc.go
@@ -7,7 +7,6 @@ import (
 	// "log"
 	"net"
 	// "reflect"
-	"crypto/tls"
 )
 
 //TODO:
@@ -36,7 +35,11 @@ var (
 	SinkholeInstance = flag.String("i", "netsarlacc-"+sinkHost, "The sinkhole instance name")
 )
 
-func httpListen() {
+func main() {
+	// Parse the command-line flags.
+	flag.Parse()
+	//starts the dispatcher
+	StartDispatcher(*NWorkers)
 	//listen for incoming connections
 	listen, err := net.Listen(CONN_TYPE, CONN_HOST+":"+CONN_PORT)
 	if err != nil {
@@ -58,38 +61,5 @@ func httpListen() {
 		}
 		go Collector(connection)
 	}
-}
-
-func httpsListen() {
-	//TLS config
-	cer, err := tls.LoadX509KeyPair("server.crt", "server.key")
-	config := &tls.Config{Certificates: []tls.Certificate{cer}}
-	
-	//listen for incoming connections
-	ln, err := tls.Listen("tcp", ":443", config)
-	
-	//Close the listener when the app closes
-	defer ln.Close()
-	
-	fmt.Println("Listening on "+CONN_TYPE, CONN_HOST+":"+CONN_PORT)
-	//Loop will run forever or until the application closes
-	for {
-		//Listen for any incoming connections
-		connection, err := listen.Accept()
-		if err != nil {
-			fmt.Println("Error accepting: ", err.Error())
-			AppLogger(err)
-		}
-		go Collector(connection)
-	}
-
-func main() {
-	// Parse the command-line flags.
-	flag.Parse()
-	//starts the dispatcher
-	StartDispatcher(*NWorkers)
-	
-	httpListen()
-	go httpsListen()
 
 }

--- a/netsarlacc.go
+++ b/netsarlacc.go
@@ -1,12 +1,12 @@
 package main
 
 import (
-	"flag"
-	"fmt"
-	"os"
-	// "log"
-	"net"
-	// "reflect"
+        "flag"
+        "fmt"
+        "os"
+        // "log"
+        "net"
+        // "reflect"
 )
 
 //TODO:
@@ -23,34 +23,34 @@ import (
 // -- Format for writing to files
 
 const (
-	// Set these to flags
-	CONN_HOST = "localhost"
-	CONN_PORT = "8888"
-	CONN_TYPE = "tcp"
+        // Set these to flags
+        CONN_HOST = "0.0.0.0"
+        CONN_PORT = "8888"
+        CONN_TYPE = "tcp"
 )
 
 var (
-	sinkHost, _      = os.Hostname()
-	NWorkers         = flag.Int("n", 4, "The number of workers to start")
-	SinkholeInstance = flag.String("i", "netsarlacc-"+sinkHost, "The sinkhole instance name")
+        sinkHost, _      = os.Hostname()
+        NWorkers         = flag.Int("n", 4, "The number of workers to start")
+        SinkholeInstance = flag.String("i", "netsarlacc-"+sinkHost, "The sinkhole instance name")
+        Logchan = make(chan string, 1024)
 )
 
 func main() {
-	// Parse the command-line flags.
-	flag.Parse()
-	//starts the dispatcher
-	StartDispatcher(*NWorkers)
-	//starts the log channel
-	logChan := make(chan string)
-	go writeLogger(logChan)
-	//listen for incoming connections
-	listen, err := net.Listen(CONN_TYPE, CONN_HOST+":"+CONN_PORT)
-	if err != nil {
-		fmt.Println("Error listening: ", err.Error())
-		AppLogger(err)
-	}
+        // Parse the command-line flags.
+        flag.Parse()
+        //starts the dispatcher
+        StartDispatcher(*NWorkers)
+        //starts the log channel
+        go writeLogger(Logchan)
+        //listen for incoming connections
+        listen, err := net.Listen(CONN_TYPE, CONN_HOST+":"+CONN_PORT)
+        if err != nil {
+                fmt.Println("Error listening: ", err.Error())
+                AppLogger(err)
+        }
 
-	//Close the listener when the app closes
+        //Close the listener when the app closes
 	defer listen.Close()
 
 	fmt.Println("Listening on "+CONN_TYPE, CONN_HOST+":"+CONN_PORT)

--- a/netsarlacc.go
+++ b/netsarlacc.go
@@ -41,7 +41,7 @@ func main() {
 	//starts the dispatcher
 	StartDispatcher(*NWorkers)
 	//starts the log channel
-	logChan := make(chan struct)
+	logChan := make(chan string)
 	//listen for incoming connections
 	listen, err := net.Listen(CONN_TYPE, CONN_HOST+":"+CONN_PORT)
 	if err != nil {

--- a/worker.go
+++ b/worker.go
@@ -110,6 +110,7 @@ func (w *Worker) Start() {
 					req_log.ReqError = true
 					req_log.ErrorMsg = err.Error()
 					jsonLog, _ := ToJSON(req_log)
+					logChan <- jsonLog
 					ConnLogger(jsonLog)
 				} else {
 					err := parseConn(buf, bufSize, &req_log)

--- a/worker.go
+++ b/worker.go
@@ -111,18 +111,15 @@ func (w *Worker) Start() {
 					req_log.ErrorMsg = err.Error()
 					jsonLog, _ := ToJSON(req_log)
 					logChan <- jsonLog
-					ConnLogger(jsonLog)
 				} else {
 					err := parseConn(buf, bufSize, &req_log)
 					if err != nil {
 						fmt.Println(err)
 						jsonLog, _ := ToJSON(req_log)
-						ConnLogger(jsonLog)
 						logChan <- jsonLog
 						work.Connection.Close()
 					} else {
 						jsonLog, _ := ToJSON(req_log)
-						ConnLogger(jsonLog)
 						logChan <- jsonLog
 						currentDir, err := os.Getwd()
 						absPath, _ := filepath.Abs(currentDir + "/template/csirtResponse.tmpl")

--- a/worker.go
+++ b/worker.go
@@ -117,10 +117,12 @@ func (w *Worker) Start() {
 						fmt.Println(err)
 						jsonLog, _ := ToJSON(req_log)
 						ConnLogger(jsonLog)
+						logChan <- jsonLog
 						work.Connection.Close()
 					} else {
 						jsonLog, _ := ToJSON(req_log)
 						ConnLogger(jsonLog)
+						logChan <- jsonLog
 						currentDir, err := os.Getwd()
 						absPath, _ := filepath.Abs(currentDir + "/template/csirtResponse.tmpl")
 						data, err := ioutil.ReadFile(absPath)


### PR DESCRIPTION
Removed connlogger kept applogger unless we want to rewrite a logger for syslog, I think the issue we had was not being able to rotate logs based on time and not knowing if we would lose connection logs.

This is what I have done I created a new goroutine call writelogger that takes connection JSON logs from a channel called Logchan. In writelogger I create a goroutine that will tick every 10 minutes and close the current file and create a new one based on the current time/date. later in writelogger I have a loop that writes to file if the ticker isnt rotating a file.

Removed lumberjack dependencies

