### PR TITLE
Smarter reads

### DIFF
--- a/config.json
+++ b/config.json
@@ -7,6 +7,7 @@
     "Readers"            : 512,
     "ReaderQueueLen"     : 32,
     "WorkerQueueLen"     : 32,
+    "MaxClientBytes"     : 65535,
     "LogDirectory"       : ".",
     "LogPrefix"          : "sinkhole",
     "TLSCert"            : "server.pem",


### PR DESCRIPTION
When clients trickle data to the server or send a large number of bytes the local kernel may make some of the data available on the socket before all of it has arrived.  In this case a single call to read() ends up truncating the total request.

This patch addresses issue #38 